### PR TITLE
Add more documentation around the API and Location ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ This plugin allows you to display the air quality values from your AirGradient d
 
  - Reporting of hardware details (manufacturer, serial number, and model) into HomeKit
 
+### Usage
+
+Once the plugin is installed in Homebridge, you will need an API Token and
+a Location ID from the AirGradient Dashboard.
+
+The API Token is available on the General Settings > Connectivity menu. You will
+have to enable API Access, if you haven't already:
+https://app.airgradient.com/settings/place?tab=1
+
+The Location ID is available on the Location menu, probably a 4-5 digit number:
+https://app.airgradient.com/settings/location
+
 ### Contributing
 
 Please feel free to contribute to this project in any way you see fit. If there are any features you would like, please open an issue and I will see what I can do, or feel free to open a pull request. If you want to help clean up or optimize the code, feel free to open a PR. I do not know TypeScript at all, I just know that this works.

--- a/config.schema.json
+++ b/config.schema.json
@@ -38,7 +38,8 @@
       "items": [
         {
           "key": "apiToken",
-          "placeholder": "Enter your API Token"
+          "placeholder": "Enter your API Token",
+          "description": "Generated from the AirGradient Dashboard"
         },
         {
           "key": "sensors",
@@ -47,7 +48,8 @@
           "items": [
             {
               "key": "sensors[].locationId",
-              "placeholder": "Enter your Location ID"
+              "placeholder": "Enter your Location ID",
+              "description": "4-5 digit number, available on the Location menu"
             },
             {
               "key": "sensors[].pollingInterval",


### PR DESCRIPTION
Thanks for the great plugin! 

I just picked up an indoor monitor and jumped in blind to Homebridge, started setting it up, but it took me a bit to understand what config I needed. Hopefully this can make it more clear.

For testing, I haven't done testing with schema, but it looks like the "description" field should work, compared to other homebridge plugins.